### PR TITLE
Fix some typo in iOS 12

### DIFF
--- a/2018-09-17-ios-12.md
+++ b/2018-09-17-ios-12.md
@@ -4,8 +4,8 @@ author: Mattt
 translator: Henry Lee
 category: ""
 excerpt: >
-  在 NSHipster ,
-  我们感兴趣的是那些最详细最细微的变化 (也可以说, _晦涩的_?)
+  在 NSHipster，
+  我们感兴趣的是那些最详细最细微的变化（也可以说, _晦涩的_?）
   但是这些细微的东西最终加起来
   却又能给我们每天的工作带来很大影响的变化
   为了庆祝 iOS 12 在这周的发布,
@@ -76,7 +76,7 @@ URLSession.shared.dataTask(with: request) {
 }
 ```
 
-这个选项 [还没有文档说明](https://developer.apple.com/documentation/foundation/nsurlrequestnetworkservicetype/nsurlnetworkservicetyperesponsivedata?language=objc)，
+这个选项[还没有文档说明](https://developer.apple.com/documentation/foundation/nsurlrequestnetworkservicetype/nsurlnetworkservicetyperesponsivedata?language=objc)，
 但是在 [WWDC 2018 Session 714: "Optimizing Your App for Today’s Internet"](https://developer.apple.com/videos/play/wwdc2018/714/) 的向导里，苹果工程师已经提到了。
 不过只有最需要极力减少请求时间的时候才能谨慎地使用这个特性，
 例如他们提到了一个场景就是一些购物应用的收银台页面可以使用，
@@ -87,7 +87,7 @@ URLSession.shared.dataTask(with: request) {
 在 WWDC 2018 里被排着队问到的最多的一个问题是 `NSUserActivity` 加入的 [`ndefMessagePayload`](https://developer.apple.com/documentation/foundation/nsuseractivity/2968463-ndefmessagepayload) 属性，
 而彼时苹果工程师在 Lab Session 回答的最多的也是“无可奉告”。
 
-但是重重迷雾终于在上周的 iPhone Xs, iPhone Xs Max 和 iPhone XR 的发布会上被揭开。
+但是重重迷雾终于在上周的 iPhone XS, iPhone XS Max 和 iPhone XR 的发布会上被揭开。
 这些设备支持在后台读取 NFC 标签，
 而且如果你在最新的设备上跑着 iOS 12，
 你将可以 ---
@@ -121,8 +121,8 @@ iOS 9 和 macOS El Capitan 作为 [AddressBook framework](https://developer.appl
 截止目前，
 你只能通过姓名或者唯一编码（identifier）搜索联系人，
 但是在 iOS 12 里，
-你能用`CNContact` 类的 [`predicateForContacts(matching:)`](https://developer.apple.com/documentation/contacts/cncontact/3020511-predicateforcontacts) 和 
-[`predicateForContacts(matchingEmailAddress:)`](https://developer.apple.com/documentation/contacts/cncontact/3020510-predicateforcontacts) 
+你能用`CNContact` 类的 [`predicateForContacts(matching:)`](https://developer.apple.com/documentation/contacts/cncontact/3020511-predicateforcontacts) 和
+[`predicateForContacts(matchingEmailAddress:)`](https://developer.apple.com/documentation/contacts/cncontact/3020510-predicateforcontacts)
 来构造谓词（predicate）用以匹配手机号码与邮件地址。
 
 
@@ -207,13 +207,13 @@ UIDevice.current.orientation == .faceUp ||
 
 为了减少文本输入之类的苦差事，
 iOS 10 为一些服从 `UITextInputTraits` 协议的控件（分别是 `UITextField` 和 `UITextView`）
-提供了[`textContentType`](https://developer.apple.com/documentation/uikit/uitextcontenttype) 属性。
+提供了 [`textContentType`](https://developer.apple.com/documentation/uikit/uitextcontenttype) 属性。
 只要提供一个具体的枚举类型，你就指定了这个控件的语义类型，
 就可以依据当前用户的信息，自动填入名字或者地址类的信息。
 
 iOS 12 和 tvOS 12 拓展了这个枚举，增加了
 [`UITextContentTypeNewPassword`](https://developer.apple.com/documentation/uikit/uitextcontenttype/2980929-newpassword)
-和 [`UITextContentTypeOneTimeCode`](https://developer.apple.com/documentation/uikit/uitextcontenttype/2980930-onetimecode)类型。
+和 [`UITextContentTypeOneTimeCode`](https://developer.apple.com/documentation/uikit/uitextcontenttype/2980930-onetimecode) 类型。
 
 当你同时指定 `.newPassword` 和 [`passwordRules`](https://nshipster.cn/uitextinputpasswordrules/) 属性的时候，
 密码自动填写功能(Password AutoFill)就能根据系统登录密码的要求自动生成一个新的密码。
@@ -238,5 +238,5 @@ textField.textContentType = .oneTimeCode
 当然，这是一次庞大的更新，
 我们期待在接下来的几周再讲解更多更深的新 API。
 
-> 对之后的内容有任何建议?
+> 对之后的内容有任何建议？
 > [来 Twitter 联系我们!](https://twitter.com/NSHipster/)


### PR DESCRIPTION
- Xs -> XS
- 空格和中文标点符号
